### PR TITLE
Zd 13662 nagpra determ culture auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-ext-nagpra",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Nagpra extension plugin for the CollectionSpace UI",
   "author": "Richard Millet <richard.millet@berkeley.edu>",
   "license": "ECL-2.0",

--- a/src/collectionobject/fields.js
+++ b/src/collectionobject/fields.js
@@ -163,7 +163,7 @@ export default (configContext) => {
               view: {
                 type: AutocompleteInput,
                 props: {
-                  source: 'concept/archculture',
+                  source: 'concept/ethculture,concept/archculture',
                 },
               },
             },


### PR DESCRIPTION
Adds concept/ethculture authority to nagpraDetermCulture

The two authorities are ordered consistently with the [claim/nagpraClaimGroupName field](https://github.com/collectionspace/cspace-ui-plugin-ext-nagpra.js/commit/40e72b193a7d560817b5984772fb55a5031cb294)