### PR TITLE
DRYD-1274: Fix museumRecords message id

### DIFF
--- a/src/place/fields.js
+++ b/src/place/fields.js
@@ -329,7 +329,7 @@ export default (configContext) => {
           [config]: {
             messages: defineMessages({
               name: {
-                id: 'field.places_nagpra.museumRecordsList.name',
+                id: 'field.places_nagpra.museumRecords.name',
                 defaultMessage: 'Museum records',
               },
             }),


### PR DESCRIPTION
**What does this do?**
Fixes typo in museumRecords message id

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1274

This was impacting the cspace-untangler which requires additional logic in order to account for the typo.

**How should this be tested? Do these changes have associated tests?**
This only changes the message id so afaik no testing is required.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran `npm run test` and `npm run lint`