### PR TITLE
DRYD-1719: Add repeating and message config

### DIFF
--- a/src/place/fields.js
+++ b/src/place/fields.js
@@ -38,6 +38,7 @@ export default (configContext) => {
                 defaultMessage: 'Basic information',
               },
             }),
+            repeating: true,
             view: {
               type: TextInput,
               props: {
@@ -61,6 +62,7 @@ export default (configContext) => {
                 defaultMessage: 'NAGPRA inventory history',
               },
             }),
+            repeating: true,
             view: {
               type: TextInput,
               props: {
@@ -84,6 +86,7 @@ export default (configContext) => {
                 defaultMessage: 'Background and records summary',
               },
             }),
+            repeating: true,
             view: {
               type: TextInput,
               props: {
@@ -107,6 +110,7 @@ export default (configContext) => {
                 defaultMessage: 'Land ownership information',
               },
             }),
+            repeating: true,
             view: {
               type: TextInput,
               props: {
@@ -333,6 +337,7 @@ export default (configContext) => {
                 defaultMessage: 'Museum records',
               },
             }),
+            repeating: true,
             view: {
               type: TextInput,
               props: {

--- a/src/place/fields.js
+++ b/src/place/fields.js
@@ -128,6 +128,12 @@ export default (configContext) => {
         },
         assertionGroup: {
           [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.places_nagpra.assertionGroup.name',
+                defaultMessage: 'Assertion',
+              },
+            }),
             repeating: true,
             view: {
               type: CompoundInput,

--- a/src/place/fields.js
+++ b/src/place/fields.js
@@ -253,6 +253,10 @@ export default (configContext) => {
           assertionRelatedRecords: {
             [config]: {
               messages: defineMessages({
+                fullName: {
+                  id: 'field.places_nagpra.assertionRelatedRecords.fullName',
+                  defaultMessage: 'Assertion museum records',
+                },
                 name: {
                   id: 'field.places_nagpra.assertionRelatedRecords.name',
                   defaultMessage: 'Museum records',
@@ -313,7 +317,7 @@ export default (configContext) => {
                   messages: defineMessages({
                     fullName: {
                       id: 'field.places_nagpra.assertionReferenceNote.fullName',
-                      defaultMessage: 'Assertion refence note',
+                      defaultMessage: 'Assertion reference note',
                     },
                     name: {
                       id: 'field.places_nagpra.assertionReferenceNote.name',


### PR DESCRIPTION
**What does this do?**
This adds missing `repeating` and `message` configuration.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1719

This was causing errors in the advanced search for the affected fields. For those missing the repeating config, they would return an `ERR_API` message because the advanced search builder incorrectly assumed they weren't repeating. The message config just helps to differentiate the fields.

**How should this be tested? Do these changes have associated tests?**
* In this repository, run `npm link`
* cd to your anthro plugin profile directory
* Run `npm link cspace-ui-plugin-ext-nagpra`
* Start the devserver for anthro, e.g `npm run devserver --back-end=https://anthro.dev.collectionspace.org`
* Navigate to the advanced search page and select 'Place'
* Search on one of the updated fields 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using anthro.dev as a backend