### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,28 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Publish NPM Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  check-code:
+    name: check-code
+    uses: collectionspace/.github/.github/workflows/check-js.yml@main
+
+  publish-npm:
+    needs: check-code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: browser-actions/setup-chrome@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
**What does this do?**
Adds a publish workflow for npm

**Why are we doing this? (with JIRA link)**
No jira

This allows us to tag releases and publish through the CI pipeline rather than manually
